### PR TITLE
save to users' history

### DIFF
--- a/RH-Groceries/src/models/history-item.ts
+++ b/RH-Groceries/src/models/history-item.ts
@@ -1,5 +1,9 @@
 export class historyItem {
     total?: number;
-    date: Date =  new Date();
+    date: string =  new Date().toString();
     sortTime: number = Date.now();
+
+    constructor(total: number) {
+        this.total = total;
+    }
 }

--- a/RH-Groceries/src/pages/buyer-list-modal/buyer-list.html
+++ b/RH-Groceries/src/pages/buyer-list-modal/buyer-list.html
@@ -123,10 +123,10 @@
     <ion-row align-items-center>
       <h3>Subtotal: ${{ (subtotal | async).$value }}</h3>
       <ion-item>
-        <ion-input name="listTip" type="text" placeholder="Tip: $0.00" [(ngModel)]="tip"></ion-input>
+        <ion-input name="listTip" type="number" placeholder="Tip: $0.00" [(ngModel)]="tip"></ion-input>
       </ion-item>
     </ion-row>
-    <button ion-button (click)="confirmDelivery()">Confirm</button>
+    <button ion-button [disabled]="tip<0" (click)="confirmDelivery()">Confirm</button>
   </div>
 
 

--- a/RH-Groceries/src/pages/history-home/history-home.html
+++ b/RH-Groceries/src/pages/history-home/history-home.html
@@ -21,7 +21,7 @@
     <div class="full-width payment-container">
       <div class="payment-info">
         <div>
-          Total Made:
+          Total Made In Tips:
         </div>
         <div>
           {{totalMade | currency:'USD':true}}
@@ -30,7 +30,7 @@
 
       <div class="payment-info">
         <div>
-          Total Spent:
+          Total Spent In Tips:
         </div>
         <div>
           {{totalSpent | currency:'USD':true}}

--- a/RH-Groceries/src/pages/history-home/history-home.ts
+++ b/RH-Groceries/src/pages/history-home/history-home.ts
@@ -16,6 +16,9 @@ export class HistoryHome {
   public totalMade: Number;
 
   constructor(public navCtrl: NavController, public navParams: NavParams, private af: AngularFire, private authService: AuthService) {
+    let date = new Date();
+    let dateString = date.toString();
+    let returnedDate = new Date(dateString);
     this.totalSpent = 0.00;
     this.totalMade = 0.00;
     let historyObservable = this.af.database.list('users/' + authService.authState.uid + '/paymentHistory', {

--- a/RH-Groceries/src/pages/list-home/list-home.html
+++ b/RH-Groceries/src/pages/list-home/list-home.html
@@ -16,7 +16,7 @@
       <button ion-button outline item-right (click)="removeListItem(item)">Remove</button>
     </ion-item>
   </ion-list>
-  <div text-center><button id="savebutton" style="margin: 0 !important;" ion-button (click)="activateList()"> Create </button></div>
+  <div text-center><button id="savebutton" style="margin: 0 !important;" ion-button [disabled]="list.length <= 0" (click)="activateList()"> Create </button></div>
   <br>
 
 
@@ -82,7 +82,7 @@
   <!-- Progress Lists HERE -->
   <div *ngIf="completedLists.length!=0">
     <hr>
-    <h4 center text-center id="setuplabel"> Devliery! </h4>
+    <h4 center text-center id="setuplabel"> Delivery! </h4>
 
     <ion-grid>
       <ion-row wrap>


### PR DESCRIPTION
Save the tip to each users’ paymentHistory list with the proper date
elements. The tip history will then be visible in the history tab.

Fixed “Devliery” typo.

Changed tip input to number and disabled if negative.

disable “create” button in list-home until there is an element in the
list.