### PR TITLE
#25 User Image

### DIFF
--- a/RH-Groceries/package.json
+++ b/RH-Groceries/package.json
@@ -19,7 +19,6 @@
     "@angular/platform-browser": "4.0.0",
     "@angular/platform-browser-dynamic": "4.0.0",
     "@ionic-native/core": "^3.4.2",
-    "@ionic-native/image-picker": "^3.5.0",
     "@ionic-native/splash-screen": "3.4.2",
     "@ionic-native/status-bar": "3.4.2",
     "@ionic/storage": "2.0.1",

--- a/RH-Groceries/src/app/app.module.ts
+++ b/RH-Groceries/src/app/app.module.ts
@@ -1,4 +1,3 @@
-import { ImagePicker } from '@ionic-native/image-picker';
 import { AuthService } from './../providers/auth-service';
 import { environment } from './../environments/environment.prod';
 import { BrowserModule } from '@angular/platform-browser';
@@ -60,7 +59,6 @@ import { HttpModule } from "@angular/http";
   providers: [
     AuthService,
     UserInfoService,
-    ImagePicker,
     StatusBar,
     SplashScreen,
     {provide: ErrorHandler, useClass: IonicErrorHandler}

--- a/RH-Groceries/src/pages/profile-setup/profile-setup.html
+++ b/RH-Groceries/src/pages/profile-setup/profile-setup.html
@@ -8,7 +8,7 @@
 
   <p center text-center id="setuplabel"> Profile Setup </p>
 
-  <form #form="ngForm" (ngSubmit)="saveProfile(form)" >
+  <form #form="ngForm" (ngSubmit)="saveProfile(form)">
 
     <ion-grid>
 
@@ -25,7 +25,8 @@
         <ion-col col-auto>Phone #:</ion-col>
         <ion-col>
           <ion-item>
-            <ion-input id="phone" type="tel" placeholder="(555) 555-5555" class="form-control" [(ngModel)]="user.phone" name="phone" required></ion-input>
+            <ion-input id="phone" type="tel" placeholder="(555) 555-5555" class="form-control" [(ngModel)]="user.phone" name="phone"
+              required></ion-input>
           </ion-item>
         </ion-col>
       </ion-row>
@@ -33,22 +34,33 @@
       <ion-row align-items-center>
         <ion-col col-auto>Profile Image:</ion-col>
         <ion-col>
-          <button ion-button type="button" (click)="pickImage()">Choose</button>
-        </ion-col>
-        <ion-col>
-          <img *ngIf="this.imageUrl" src="" alt="profile image">
+          <input #fileInput id="fileInput" type="file" (change)="photoSelected($event)" style="display:none"> <button type="button"
+            ion-button (click)="fileInput.click()">Choose</button>
+          <button type="button" ion-button color="danger" *ngIf="photo && !loadingImage && tempPhotoUrl" (click)="removePhoto()">Clear Photo</button>
         </ion-col>
       </ion-row>
-      <br>
+
+      <ion-row align-items-center>
+        <ion-col text-center>
+          <div class="spinner-img" *ngIf="loadingImage">
+            <ion-spinner></ion-spinner>
+            <p>Uploading...</p>
+          </div>
+          <img *ngIf="photo && !loadingImage && tempPhotoUrl" class="profile-img" [src]="tempPhotoUrl" alt="Missing Photo">
+        </ion-col>
+      </ion-row>
+
+      <div text-center><button id="savebutton" [disabled]="!form.valid || !user || user.phone.length != 14 || user.address.length <= 0" ion-button
+          type="submit"> Finish </button></div>
 
       <ion-row align-items-center>
         <h2>Payments:</h2>
-        <p>We use Stripe Connect as our primary payment service which allows safe payments between users. After finishing your profile here, you will be given an unactivated Stripe account which will give you limited access to buying and shopping. Stripe will send an email with instructions on how to activate your account which will remove all limitations.
+        <p>We use Stripe Connect as our primary payment service which allows safe payments between users. After finishing your
+          profile here, you will be given an unactivated Stripe account which will give you limited access to buying and
+          shopping. Stripe will send an email with instructions on how to activate your account which will remove all limitations.
       </ion-row>
 
     </ion-grid>
-
-    <div text-center><button id="savebutton" [disabled]="!form.valid || !user || user.phone.length != 14 || user.address.length <= 0" ion-button type="submit"> Finish </button></div>
 
   </form>
 

--- a/RH-Groceries/src/pages/profile-setup/profile-setup.scss
+++ b/RH-Groceries/src/pages/profile-setup/profile-setup.scss
@@ -4,8 +4,26 @@
 }
 
 #savebutton {
-    margin-top: 30px;
+    margin-top: 5px;
+    margin-bottom: 15px;
     width: 200px;
     height: 60px;
     font-size: 24px;
+}
+
+.profile-img {
+    width: 100px !important;
+    height: 100px !important;
+}
+
+.spinner-img {
+    text-align: center;
+    ion-spinner {
+        height: 50px;
+        width: 50px;
+    }
+    p {
+        position: absolute;
+        bottom: 0px;
+    }
 }

--- a/RH-Groceries/src/pages/profile-setup/profile-setup.ts
+++ b/RH-Groceries/src/pages/profile-setup/profile-setup.ts
@@ -3,7 +3,6 @@ import { AuthService } from './../../providers/auth-service';
 import { TabPage } from './../tab-page/tab-page';
 import { Component } from '@angular/core';
 import { IonicPage, NavController, NavParams } from 'ionic-angular';
-import { ImagePicker } from '@ionic-native/image-picker';
 import * as firebase from 'firebase';
 import { User } from "../../models/user";
 
@@ -16,10 +15,12 @@ import { User } from "../../models/user";
 export class ProfileSetup {
 
   public user: User;
-  public imageUrl: string = "";
+  public loadingImage: boolean = false;
+  public tempPhotoUrl: string;
+  private photo: File;
 
-  constructor(public navCtrl: NavController, public navParams: NavParams, private imagePicker: ImagePicker, private authService: AuthService, private http: Http) {
-        this.user = new User();
+  constructor(public navCtrl: NavController, public navParams: NavParams, private authService: AuthService, private http: Http) {
+    this.user = new User();
   }
 
   ionViewDidLoad() {
@@ -38,31 +39,46 @@ export class ProfileSetup {
     });
 
     this.user.name = this.authService.rfUser.name;
-    firebase.database().ref().child('users').child(this.authService.authState.uid).set(this.user, (err) => {
-      if (err) {
-        //do something
-      }
-      else {
-
+    if (this.photo && this.tempPhotoUrl) {
+      this.loadingImage = true;
+      const metadata = { "content-type": this.photo.type }
+      const storageRef: firebase.storage.Reference = firebase.storage().ref().child("photos").child(this.authService.authState.uid);
+      const uploadTask: firebase.storage.UploadTask = storageRef.put(this.photo, metadata);
+      uploadTask.then((uploadSnapshot: firebase.storage.UploadTaskSnapshot) => {
+        const downloadUrl = uploadSnapshot.downloadURL;
+        this.user.image = downloadUrl;
+        firebase.database().ref().child('users').child(this.authService.authState.uid).set(this.user, (err) => {
+          this.loadingImage = false;
+          this.navCtrl.setRoot(TabPage);
+        });
+      });
+    }
+    else {
+      firebase.database().ref().child('users').child(this.authService.authState.uid).set(this.user, (err) => {
         this.navCtrl.setRoot(TabPage);
-      }
-    });
-  }
-
-  pickImage() {
-    console.log("Opening image picker");
-    let options = {
-      maximumImagesCount: 1,
-      width: 500,
-      height: 500,
-      quality: 50
+      });
     }
 
-    this.imagePicker.getPictures(options).then((file_uris) => {
-      this.imageUrl = file_uris[0];
-      //do something
-    }, (err) => {
-      console.log('Picker failed (are you running in a mobile simulator?)');
-    });
+  }
+
+  photoSelected(event: any) {
+    this.photo = event.target.files[0];
+    if (this.photo) {
+      this.loadingImage = true;
+      const metadata = { "content-type": this.photo.type }
+      const storageRef: firebase.storage.Reference = firebase.storage().ref().child("photos").child(this.authService.authState.uid + "temp");
+      const uploadTask: firebase.storage.UploadTask = storageRef.put(this.photo, metadata);
+      uploadTask.then((uploadSnapshot: firebase.storage.UploadTaskSnapshot) => {
+        const downloadUrl = uploadSnapshot.downloadURL;
+        this.tempPhotoUrl = downloadUrl;
+        this.loadingImage = false;
+      });
+    }
+
+  }
+
+  removePhoto() {
+    this.tempPhotoUrl = "";
+    this.photo = null;
   }
 }

--- a/RH-Groceries/src/pages/profile-setup/profile-setup.ts
+++ b/RH-Groceries/src/pages/profile-setup/profile-setup.ts
@@ -62,8 +62,9 @@ export class ProfileSetup {
   }
 
   photoSelected(event: any) {
-    this.photo = event.target.files[0];
-    if (this.photo) {
+    let newphoto = event.target.files[0];
+    if (newphoto) {
+      this.photo = newphoto;
       this.loadingImage = true;
       const metadata = { "content-type": this.photo.type }
       const storageRef: firebase.storage.Reference = firebase.storage().ref().child("photos").child(this.authService.authState.uid + "temp");

--- a/RH-Groceries/src/pages/profile/profile.html
+++ b/RH-Groceries/src/pages/profile/profile.html
@@ -23,8 +23,10 @@
           <p>Uploading...</p>
         </div>
         <img *ngIf="photo && !loadingImage && tempPhotoUrl" class="profile-img" [src]="tempPhotoUrl" alt="Missing Photo">
-        <img *ngIf="(!photo && !loadingImage && user && user.image) as imageUrl; else missingPhotoTemplate" class="profile-img" [src]="imageUrl" alt="Missing Photo">
-        <img *ngIf="(!photo && !loadingImage && (!user || !user.image))" class="profile-img" src="assets/images/missing_photo.png" alt="Missing Photo">
+        <img *ngIf="(!photo && !loadingImage && user && user.image) as imageUrl; else missingPhotoTemplate" class="profile-img" [src]="imageUrl"
+          alt="Missing Photo">
+        <img *ngIf="(!photo && !loadingImage && (!user || !user.image))" class="profile-img" src="assets/images/missing_photo.png"
+          alt="Missing Photo">
       </ion-col>
       <ion-col>
         <p>{{user?.name}}</p>
@@ -58,6 +60,7 @@
         <ion-col>
           <input #fileInput id="fileInput" type="file" (change)="photoSelected($event)" style="display:none"> <button ion-button
             (click)="fileInput.click()">Choose</button>
+          <button type="button" ion-button color="danger" *ngIf="photo && !loadingImage && tempPhotoUrl" (click)="resetPhoto()">reset Photo</button>
         </ion-col>
       </ion-row>
     </div>

--- a/RH-Groceries/src/pages/profile/profile.html
+++ b/RH-Groceries/src/pages/profile/profile.html
@@ -16,12 +16,15 @@
       </ion-col>
     </ion-row>
 
-    <ion-row>
+    <ion-row align-items-center>
       <ion-col col-auto>
-        <img *ngIf="buyerUser?.image as imageUrl; else missingPhotoTemplate" id="profile-img" [src]="imageUrl" alt="Missing Photo">
-        <ng-template #missingPhotoTemplate>
-          <img id="profile-img" src="assets/images/missing_photo.png" alt="Missing Photo">
-        </ng-template>
+        <div class="spinner-img" *ngIf="loadingImage">
+          <ion-spinner></ion-spinner>
+          <p>Uploading...</p>
+        </div>
+        <img *ngIf="photo && !loadingImage && tempPhotoUrl" class="profile-img" [src]="tempPhotoUrl" alt="Missing Photo">
+        <img *ngIf="(!photo && !loadingImage && user && user.image) as imageUrl; else missingPhotoTemplate" class="profile-img" [src]="imageUrl" alt="Missing Photo">
+        <img *ngIf="(!photo && !loadingImage && (!user || !user.image))" class="profile-img" src="assets/images/missing_photo.png" alt="Missing Photo">
       </ion-col>
       <ion-col>
         <p>{{user?.name}}</p>
@@ -53,10 +56,8 @@
       <ion-row align-items-center>
         <ion-col col-auto>Profile Image:</ion-col>
         <ion-col>
-          <button ion-button type="button" (click)="pickImage()">Choose</button>
-        </ion-col>
-        <ion-col>
-          <img *ngIf="this.imageUrl" src="" alt="profile image">
+          <input #fileInput id="fileInput" type="file" (change)="photoSelected($event)" style="display:none"> <button ion-button
+            (click)="fileInput.click()">Choose</button>
         </ion-col>
       </ion-row>
     </div>

--- a/RH-Groceries/src/pages/profile/profile.scss
+++ b/RH-Groceries/src/pages/profile/profile.scss
@@ -1,6 +1,20 @@
-#profile-img {
-    width: 100px;
-    height: 100px;
+.profile-img {
+    width: 100px !important;
+    height: 100px !important;
+}
+
+.spinner-img {
+    width: 100px !important;
+    height: 100px !important;
+    text-align: center;
+    ion-spinner {
+        height: 50px;
+        width: 50px;
+    }
+    p {
+        position: absolute;
+        bottom: 0px;
+    }
 }
 
 .icons {

--- a/RH-Groceries/src/pages/profile/profile.ts
+++ b/RH-Groceries/src/pages/profile/profile.ts
@@ -3,7 +3,6 @@ import { AuthService } from './../../providers/auth-service';
 import { Component } from '@angular/core';
 import { IonicPage, NavController, NavParams } from 'ionic-angular';
 import * as firebase from 'firebase';
-import { ImagePicker } from '@ionic-native/image-picker';
 import { RatingModule } from "ngx-rating";
 
 @IonicPage()
@@ -15,11 +14,13 @@ export class Profile {
 
   public user: User;
   public editing: boolean = false;
+  public loadingImage: boolean = false;
+  public tempPhotoUrl: string;
   private backupAddr: string;
   private backupPhone: string;
-  public imageUrl: string = "";
+  private photo: File;
 
-  constructor(public navCtrl: NavController, public navParams: NavParams, private imagePicker: ImagePicker, public authService: AuthService) {
+  constructor(public navCtrl: NavController, public navParams: NavParams, public authService: AuthService) {
     firebase.database().ref('/users/' + authService.authState.uid).on("value", (snapshot) => {
       this.user = snapshot.val();
       //console.log(snapshot.val());
@@ -46,6 +47,8 @@ export class Profile {
   cancel() {
     this.user.address = this.backupAddr;
     this.user.phone = this.backupPhone;
+    this.tempPhotoUrl = "";
+    this.photo = null;
     this.editing = false;
   }
 
@@ -56,32 +59,44 @@ export class Profile {
     }
     var strippedUser = {
       phone: this.user.phone,
-      address: this.user.address
+      address: this.user.address,
+      image: this.user.image
     }
-    firebase.database().ref().child('users').child(this.authService.authState.uid).update(strippedUser, (err) => {
-      if (err) {
-        //do something
-      }
-      else {
+    if (this.photo && this.tempPhotoUrl) {
+      this.loadingImage = true;
+      const metadata = { "content-type": this.photo.type }
+      const storageRef: firebase.storage.Reference = firebase.storage().ref().child("photos").child(this.authService.authState.uid);
+      const uploadTask: firebase.storage.UploadTask = storageRef.put(this.photo, metadata);
+      uploadTask.then((uploadSnapshot: firebase.storage.UploadTaskSnapshot) => {
+        const downloadUrl = uploadSnapshot.downloadURL;
+        strippedUser.image = downloadUrl;
+        firebase.database().ref().child('users').child(this.authService.authState.uid).update(strippedUser, (err) => {
+          this.editing = false;
+          this.loadingImage = false;
+          this.photo = null;
+          this.tempPhotoUrl = "";
+        });
+      });
+    }
+    else {
+      firebase.database().ref().child('users').child(this.authService.authState.uid).update(strippedUser, (err) => {
         this.editing = false;
-      }
-    });
+      });
+    }
+
+
   }
 
-  pickImage() {
-    console.log("Opening image picker");
-    let options = {
-      maximumImagesCount: 1,
-      width: 500,
-      height: 500,
-      quality: 50
-    }
-
-    this.imagePicker.getPictures(options).then((file_uris) => {
-      this.imageUrl = file_uris[0];
-      //do something
-    }, (err) => {
-      console.log('Picker failed (are you running in a mobile simulator?)');
+  photoSelected(event: any) {
+    this.loadingImage = true;
+    this.photo = event.target.files[0];
+    const metadata = { "content-type": this.photo.type }
+    const storageRef: firebase.storage.Reference = firebase.storage().ref().child("photos").child(this.authService.authState.uid + "temp");
+    const uploadTask: firebase.storage.UploadTask = storageRef.put(this.photo, metadata);
+    uploadTask.then((uploadSnapshot: firebase.storage.UploadTaskSnapshot) => {
+      const downloadUrl = uploadSnapshot.downloadURL;
+      this.tempPhotoUrl = downloadUrl;
+      this.loadingImage = false;
     });
   }
 

--- a/RH-Groceries/src/pages/profile/profile.ts
+++ b/RH-Groceries/src/pages/profile/profile.ts
@@ -88,16 +88,25 @@ export class Profile {
   }
 
   photoSelected(event: any) {
-    this.loadingImage = true;
-    this.photo = event.target.files[0];
-    const metadata = { "content-type": this.photo.type }
-    const storageRef: firebase.storage.Reference = firebase.storage().ref().child("photos").child(this.authService.authState.uid + "temp");
-    const uploadTask: firebase.storage.UploadTask = storageRef.put(this.photo, metadata);
-    uploadTask.then((uploadSnapshot: firebase.storage.UploadTaskSnapshot) => {
-      const downloadUrl = uploadSnapshot.downloadURL;
-      this.tempPhotoUrl = downloadUrl;
-      this.loadingImage = false;
-    });
+    let newphoto = event.target.files[0];
+    if (newphoto) {
+      this.photo = newphoto;
+      this.loadingImage = true;
+      const metadata = { "content-type": this.photo.type }
+      const storageRef: firebase.storage.Reference = firebase.storage().ref().child("photos").child(this.authService.authState.uid + "temp");
+      const uploadTask: firebase.storage.UploadTask = storageRef.put(this.photo, metadata);
+      uploadTask.then((uploadSnapshot: firebase.storage.UploadTaskSnapshot) => {
+        const downloadUrl = uploadSnapshot.downloadURL;
+        this.tempPhotoUrl = downloadUrl;
+        this.loadingImage = false;
+      });
+    }
+
+  }
+
+  resetPhoto() {
+    this.tempPhotoUrl = "";
+    this.photo = null;
   }
 
 }


### PR DESCRIPTION
closes #25 

Allow users to add profile pictures in both the profile-setup and profile pages.

Choosing an image will first upload the picture to their temp picture location (to be able to view the picture in the page and allow for “reverts”) and then upload to the actual location on the actual save. The locations in firebase storage are their id for the main location and their id + “temp” for the temp location.

It will display a loading spinner when uploading so the user doesn’t think nothing is happening.