### PR TITLE
Small screen UI cleanup

### DIFF
--- a/RH-Groceries/src/pages/buyer-list-modal/buyer-list.html
+++ b/RH-Groceries/src/pages/buyer-list-modal/buyer-list.html
@@ -19,6 +19,23 @@
 
 <ion-content padding>
 
+  <ion-card (click)="displayReviews('shopper')" *ngIf="foundShopper && (shopper | async) as shopperUser">
+    <ion-item>
+      <ion-avatar item-left>
+        <img *ngIf="shopperUser.image as imageUrl; else missingPhotoTemplate" [src]="imageUrl" alt="Missing Photo">
+        <ng-template #missingPhotoTemplate>
+          <img src="assets/images/missing_photo.png" alt="Missing Photo">
+        </ng-template>
+      </ion-avatar>
+      <h1>{{ shopperUser?.name }}</h1>
+      <h3>{{ shopperUser?.phone }}</h3>
+      <h3 style="text-decoration: underline;">Shopper Rating</h3>
+    </ion-item>
+    <div text-center>
+      <rating [(ngModel)]="shopperUser && shopperUser.shopperRating" [float]="true" [readonly]="true"></rating><span>{{shopperUser?.shopperRating | number : '1.1-1'}}</span>
+    </div>
+  </ion-card>
+
   <!-- Active List Content -->
   <div *ngIf="(listeningListStatusData | async).$value==1">
     <ion-list>
@@ -31,32 +48,16 @@
 
   <!-- List Needing Approval -->
   <div *ngIf="(listeningListStatusData | async).$value==2">
-    <ion-card (click)="displayReviews('shopper')">
-      <ion-item *ngIf="(shopper | async) as shopperUser">
-        <ion-avatar item-left>
-          <img *ngIf="(shopper | async)?.image as imageUrl; else missingPhotoTemplate" [src]="imageUrl" alt="Missing Photo">
-          <ng-template #missingPhotoTemplate>
-            <img src="assets/images/missing_photo.png" alt="Missing Photo">
-          </ng-template>
-        </ion-avatar>
-        <h1>{{ shopperUser?.name }}</h1>
-        <h3>{{ shopperUser?.phone }}</h3>
-        <h3 style="text-decoration: underline;">Shopper Rating</h3>
-        <rating [(ngModel)]="shopperUser && shopperUser.shopperRating" [float]="true" [readonly]="true"></rating><span>{{shopperUser?.shopperRating | number : '1.1-1'}}</span>
-        <br>
-      </ion-item>
-    </ion-card>
-
     <ion-list>
       <ion-item *ngFor="let item of items">
         {{ item }}
       </ion-item>
     </ion-list>
     <ion-row>
-    <button ion-button (click)="confirmShopper()">
+      <button ion-button (click)="confirmShopper()">
       Confirm
     </button>
-    <button ion-button color="danger" (click)="rejectShopper()">
+      <button ion-button color="danger" (click)="rejectShopper()">
       Reject
     </button>
     </ion-row>
@@ -67,21 +68,6 @@
 
   <!-- List In Progress -->
   <div *ngIf="(listeningListStatusData | async).$value==3">
-    <ion-card (click)="displayReviews('shopper')">
-      <ion-item *ngIf="(shopper | async) as shopperUser">
-        <ion-avatar item-left>
-          <img *ngIf="(shopper | async)?.image as imageUrl; else missingPhotoTemplate" [src]="imageUrl" alt="Missing Photo">
-          <ng-template #missingPhotoTemplate>
-            <img src="assets/images/missing_photo.png" alt="Missing Photo">
-          </ng-template>
-        </ion-avatar>
-        <h1>{{ shopperUser?.name }}</h1>
-        <h3>{{ shopperUser?.phone }}</h3>
-        <h3 style="text-decoration: underline;">Shopper Rating</h3>
-        <rating [(ngModel)]="shopperUser && shopperUser.shopperRating" [float]="true" [readonly]="true"></rating><span>{{shopperUser?.shopperRating | number : '1.1-1'}}</span>
-        <br>
-      </ion-item>
-    </ion-card>
 
     <ion-list>
       <h3>Items Left</h3>
@@ -100,21 +86,6 @@
 
   <!-- Delivery Confirm -->
   <div *ngIf="(listeningListStatusData | async).$value==4">
-    <ion-card (click)="displayReviews('shopper')">
-      <ion-item *ngIf="(shopper | async) as shopperUser">
-        <ion-avatar item-left>
-          <img *ngIf="(shopper | async)?.image as imageUrl; else missingPhotoTemplate" [src]="imageUrl" alt="Missing Photo">
-          <ng-template #missingPhotoTemplate>
-            <img src="assets/images/missing_photo.png" alt="Missing Photo">
-          </ng-template>
-        </ion-avatar>
-        <h1>{{ shopperUser?.name }}</h1>
-        <h3>{{ shopperUser?.phone }}</h3>
-        <h3 style="text-decoration: underline;">Shopper Rating</h3>
-        <rating [(ngModel)]="shopperUser && shopperUser.shopperRating" [float]="true" [readonly]="true"></rating><span>{{shopperUser?.shopperRating | number : '1.1-1'}}</span>
-        <br>
-      </ion-item>
-    </ion-card>
 
     <ion-list>
       <h3>Items Left</h3>
@@ -144,23 +115,6 @@
 
   <!-- Review Shopper -->
   <div *ngIf="(listeningListStatusData | async).$value==5">
-    <ion-card (click)="displayReviews('shopper')">
-      <ion-item *ngIf="(shopper | async) as shopperUser">
-        <ion-avatar item-left>
-          <img *ngIf="(shopper | async)?.image as imageUrl; else missingPhotoTemplate" [src]="imageUrl" alt="Missing Photo">
-          <ng-template #missingPhotoTemplate>
-            <img src="assets/images/missing_photo.png" alt="Missing Photo">
-          </ng-template>
-        </ion-avatar>
-        <h1>{{ shopperUser?.name }}</h1>
-        <h3>{{ shopperUser?.phone }}</h3>
-        <h3 style="text-decoration: underline;">Shopper Rating</h3>
-        <rating [(ngModel)]="shopperUser && shopperUser.shopperRating" [float]="true" [readonly]="true"></rating><span>{{shopperUser?.shopperRating | number : '1.1-1'}}</span>
-        <br>
-      </ion-item>
-    </ion-card>
-
-    <br>
 
     <h3>Total Spent: {{ total | currency:'USD':true}}</h3>
     <hr>

--- a/RH-Groceries/src/pages/buyer-list-modal/buyer-list.scss
+++ b/RH-Groceries/src/pages/buyer-list-modal/buyer-list.scss
@@ -1,15 +1,20 @@
 page-buyer-list {
-    ion-grid {
-        margin-top: 60px;
-        * {
-            padding-bottom: 10px;
-        }
-        #rating-num {
-            padding-left: 15px;
-        }
+  ion-grid {
+    margin-top: 60px;
+    * {
+      padding-bottom: 10px;
     }
-    ion-title {
-		padding: 0px 0px 0px 30px !important;
-		text-align: center;
+    #rating-num {
+      padding-left: 15px;
     }
+  }
+  ion-title {
+    padding: 0px 0px 0px 30px !important;
+    text-align: center;
+  }
+  ion-card {
+    ion-label {
+      margin-bottom: 0px !important;
+    }
+  }
 }

--- a/RH-Groceries/src/pages/buyer-list-modal/buyer-list.scss
+++ b/RH-Groceries/src/pages/buyer-list-modal/buyer-list.scss
@@ -9,6 +9,7 @@ page-buyer-list {
         }
     }
     ion-title {
-        padding: 0px 35px !important;
+		padding: 0px 0px 0px 30px !important;
+		text-align: center;
     }
 }

--- a/RH-Groceries/src/pages/list-for-shopper-modal/list-for-shopper-modal.html
+++ b/RH-Groceries/src/pages/list-for-shopper-modal/list-for-shopper-modal.html
@@ -17,8 +17,8 @@
 
 
 <ion-content padding>
-  <ion-card *ngIf="!blacklisted" (click)="displayReviews('buyer')">
-    <ion-item *ngIf="(buyer | async) as buyerUser">
+  <ion-card *ngIf="!blacklisted && (buyer | async) as buyerUser" (click)="displayReviews('buyer')">
+    <ion-item>
       <ion-avatar item-left>
         <img *ngIf="buyerUser?.image as imageUrl; else missingPhotoTemplate" [src]="imageUrl" alt="Missing Photo">
         <ng-template #missingPhotoTemplate>
@@ -29,9 +29,10 @@
       <h3>{{ buyerUser?.phone }}</h3>
       <h3>{{ buyerUser?.address }}</h3>
       <h3 style="text-decoration: underline;">Buyer Rating</h3>
-      <rating [(ngModel)]="buyerUser && buyerUser.buyerRating" [float]="true" [readonly]="true"></rating><span>{{buyerUser?.buyerRating | number : '1.1-1'}}</span>
-      <br>
     </ion-item>
+    <div text-center>
+      <rating [(ngModel)]="buyerUser && buyerUser.buyerRating" [float]="true" [readonly]="true"></rating><span>{{buyerUser?.buyerRating | number : '1.1-1'}}</span>
+    </div>
   </ion-card>
 
   <!-- Blacklisted Shopper View -->
@@ -64,11 +65,6 @@
       </ion-item>
     </ion-list>
   </div>
-
-
-
-
-
 
   <!-- Actively Shopping HERE -->
   <div *ngIf="(listeningListStatusData | async).$value==3">

--- a/RH-Groceries/src/pages/list-for-shopper-modal/list-for-shopper-modal.scss
+++ b/RH-Groceries/src/pages/list-for-shopper-modal/list-for-shopper-modal.scss
@@ -1,5 +1,6 @@
 page-list-for-shopper-modal {
-    ion-title {
-        padding: 0px 35px !important;
-    }
+  ion-title {
+    padding: 0px 0px 0px 30px !important;
+    text-align: center;
+  }
 }

--- a/RH-Groceries/src/pages/list-for-shopper-modal/list-for-shopper-modal.scss
+++ b/RH-Groceries/src/pages/list-for-shopper-modal/list-for-shopper-modal.scss
@@ -3,4 +3,9 @@ page-list-for-shopper-modal {
     padding: 0px 0px 0px 30px !important;
     text-align: center;
   }
+  ion-card {
+    ion-label {
+      margin-bottom: 0px !important;
+    }
+  }
 }

--- a/RH-Groceries/src/pages/list-home/list-home.html
+++ b/RH-Groceries/src/pages/list-home/list-home.html
@@ -1,5 +1,5 @@
 <ion-content padding>
-  <h4 center text-center id="setuplabel"> Make a New List </h4>
+  <h6 center text-center id="setuplabel"> Make a New List </h6>
 
 
   <ion-row align-items-center>
@@ -35,7 +35,7 @@
   <!-- Active Lists HERE -->
   <div *ngIf="buyerLists.length!=0">
     <hr>
-    <h4 center text-center id="setuplabel"> Active Lists </h4>
+    <h6 center text-center id="setuplabel"> Active Lists </h6>
 
     <ion-grid>
       <ion-row wrap>

--- a/RH-Groceries/src/pages/list-home/list-home.html
+++ b/RH-Groceries/src/pages/list-home/list-home.html
@@ -35,7 +35,7 @@
   <!-- Active Lists HERE -->
   <div *ngIf="buyerLists.length!=0">
     <hr>
-    <h6 center text-center id="setuplabel"> Active Lists </h6>
+    <h6 center text-center id="setuplabel">Active Lists</h6>
 
     <ion-grid>
       <ion-row wrap>
@@ -54,7 +54,7 @@
   <!-- Need Approval Lists HERE -->
   <div *ngIf="waitingLists.length!=0">
     <hr>
-    <h4 center text-center id="setuplabel"> Need Approval... </h4>
+    <h4 center text-center id="setuplabel">Need Approval</h4>
 
     <ion-grid>
       <ion-row wrap>
@@ -73,7 +73,7 @@
   <!-- Progress Lists HERE -->
   <div *ngIf="inProgressLists.length!=0">
     <hr>
-    <h4 center text-center id="setuplabel"> In Progress... </h4>
+    <h4 center text-center id="setuplabel">In Progress</h4>
 
     <ion-grid>
       <ion-row wrap>
@@ -91,7 +91,7 @@
   <!-- Progress Lists HERE -->
   <div *ngIf="completedLists.length!=0">
     <hr>
-    <h4 center text-center id="setuplabel"> Delivery! </h4>
+    <h4 center text-center id="setuplabel">Delivery!</h4>
 
     <ion-grid>
       <ion-row wrap>

--- a/RH-Groceries/src/pages/list-home/list-home.scss
+++ b/RH-Groceries/src/pages/list-home/list-home.scss
@@ -1,3 +1,5 @@
 page-list-home {
-    
+    #setuplabel {
+		font-size: 37px;
+	}
 }

--- a/RH-Groceries/src/pages/profile/profile.html
+++ b/RH-Groceries/src/pages/profile/profile.html
@@ -10,7 +10,7 @@
     </ng-template>
   </div>
 
-  <ion-grid>
+  <ion-grid style="position: relative;">
 
     <ion-row>
       <ion-col text-center id="Profile">

--- a/RH-Groceries/src/pages/shop-home/shop-home.html
+++ b/RH-Groceries/src/pages/shop-home/shop-home.html
@@ -2,7 +2,7 @@
 
   <!-- Waiting for Response HERE -->
   <div *ngIf="waitingForConfirmationLists.length!=0">
-    <h4 center text-center id="setuplabel"> Waiting for Buyer... </h4>
+    <h4 center text-center class="setuplabel">Waiting for Buyer</h4>
 
     <ion-grid>
       <ion-row wrap>
@@ -15,17 +15,17 @@
         </ion-col>
       </ion-row>
     </ion-grid>
+    <hr>
   </div>
 
-  
+
 
 
 
 
   <!--- Active List View HERE -->
   <div *ngIf="activeLists.length!=0">
-    <hr>
-    <h4 center text-center id="setuplabel"> Active Lists </h4>
+    <h4 center text-center class="setuplabel">Active Lists</h4>
 
     <ion-grid>
       <ion-row wrap>
@@ -44,7 +44,7 @@
   <!--- In Progress List View HERE -->
   <div *ngIf="inProgressLists.length!=0">
     <hr>
-    <h4 center text-center id="setuplabel"> In Progress... </h4>
+    <h4 center text-center class="setuplabel">In Progress</h4>
 
     <ion-grid>
       <ion-row wrap>
@@ -62,7 +62,7 @@
   <!--- Waiting for Delivery Confirmation List View HERE -->
   <div *ngIf="deliveredLists.length!=0">
     <hr>
-    <h4 center text-center id="setuplabel"> Delivered... </h4>
+    <h4 center text-center class="setuplabel">Delivered</h4>
 
     <ion-grid>
       <ion-row wrap>

--- a/RH-Groceries/src/pages/shop-home/shop-home.scss
+++ b/RH-Groceries/src/pages/shop-home/shop-home.scss
@@ -1,3 +1,7 @@
 page-shop-home {
+	.setuplabel {
+		font-size: 35px;
+		margin-bottom: 0px !important;
+	}
 
 }


### PR DESCRIPTION
This includes minor changes to the UI to make sure it fits on all screens (only tested down to the iPhone 5, which is 4 inchs).

1. Cleaned up various title’s padding, text, and font-size to make sure they fit without wrapping on small screens.

2. Extracted the user card in the buyer list modal similar to how it is done in the shopper list modal (so that the user card is not recreated each time the list’s status changes, and also removes code duplication).

3. Fixed the layout and margins of the user card in the two modals so that the rating is on its own line and cannot get pushed off the edge on small screens (only show 3-4 stars with no label).

4. Fixed the issue where the profile page was being placed behind the navbar instead of inside the ion-content below it. This was because the rating is set to position:absolute which means it’s parents position is absolute unless specified to be relative. 